### PR TITLE
export more args for addPortMapping

### DIFF
--- a/lib/upnp.js
+++ b/lib/upnp.js
@@ -407,12 +407,16 @@ class UPNPService {
   /**
    * Attempt to add port mapping to local IP.
    * @param {String} remote - Remote IP.
-   * @param {Number} src - Remote port.
-   * @param {Number} dest - Local port.
+   * @param {Number} externalPort - Remote port.
+   * @param {Number} internalPort - Local port.
+   * @param {Array[String]} internalHosts - Local ips.
+   * @param {Number} leaseDuration - lease duration.
+   * @param {'TCP'|'UDP'} protocol - protocol.
+   * @param {String} clientDesc - client description.
    * @returns {Promise}
    */
 
-  async addPortMapping(remote, externalPort, internalPort, internalHosts, leaseDuration) {
+  async addPortMapping(remote, externalPort, internalPort, internalHosts, leaseDuration, protocol, clientDesc) {
     const action = 'AddPortMapping';
     if (!internalHosts || !internalHosts.length) {
       internalHosts = IP.getPrivate();
@@ -424,11 +428,11 @@ class UPNPService {
     const xml = await this.soapRequest(action, [
       ['NewRemoteHost', remote],
       ['NewExternalPort', externalPort],
-      ['NewProtocol', 'TCP'],
+      ['NewProtocol', (protocol || 'TCP').toUpperCase()],
       ['NewInternalClient', internalHosts],
       ['NewInternalPort', internalPort],
       ['NewEnabled', 'True'],
-      ['NewPortMappingDescription', 'upnp:nodejs'],
+      ['NewPortMappingDescription', clientDesc || 'upnp:nodejs'],
       ['NewLeaseDuration', leaseDuration || 0]
     ]);
 

--- a/lib/upnp.js
+++ b/lib/upnp.js
@@ -409,14 +409,14 @@ class UPNPService {
    * @param {String} remote - Remote IP.
    * @param {Number} externalPort - Remote port.
    * @param {Number} internalPort - Local port.
-   * @param {Array[String]} internalHosts - Local ips.
    * @param {Number} leaseDuration - lease duration.
    * @param {'TCP'|'UDP'} protocol - protocol.
    * @param {String} clientDesc - client description.
+   * @param {Array[String]} internalHosts - Local ips.
    * @returns {Promise}
    */
 
-  async addPortMapping(remote, externalPort, internalPort, internalHosts, leaseDuration, protocol, clientDesc) {
+  async addPortMapping(remote, externalPort, internalPort, leaseDuration, protocol, clientDesc, internalHosts) {
     const action = 'AddPortMapping';
     if (!internalHosts || !internalHosts.length) {
       internalHosts = IP.getPrivate();

--- a/lib/upnp.js
+++ b/lib/upnp.js
@@ -412,22 +412,24 @@ class UPNPService {
    * @returns {Promise}
    */
 
-  async addPortMapping(remote, src, dest) {
+  async addPortMapping(remote, externalPort, internalPort, internalHosts, leaseDuration) {
     const action = 'AddPortMapping';
-    const local = IP.getPrivate();
+    if (!internalHosts || !internalHosts.length) {
+      internalHosts = IP.getPrivate();
+    }
 
-    if (local.length === 0)
+    if (internalHosts.length === 0)
       throw new Error('Cannot determine local IP.');
 
     const xml = await this.soapRequest(action, [
       ['NewRemoteHost', remote],
-      ['NewExternalPort', src],
+      ['NewExternalPort', externalPort],
       ['NewProtocol', 'TCP'],
-      ['NewInternalClient', local[0]],
-      ['NewInternalPort', dest],
+      ['NewInternalClient', internalHosts],
+      ['NewInternalPort', internalPort],
       ['NewEnabled', 'True'],
       ['NewPortMappingDescription', 'upnp:nodejs'],
-      ['NewLeaseDuration', 0]
+      ['NewLeaseDuration', leaseDuration || 0]
     ]);
 
     const child = xml.find('AddPortMappingResponse');


### PR DESCRIPTION
some ips for virtual-machine, and some gateway may refuse the request for the invalid ips; so it's necessary to set the NewInternalClient by the caller.