### PR TITLE
Add support for "AddAnyPortMapping"

### DIFF
--- a/lib/upnp.js
+++ b/lib/upnp.js
@@ -405,6 +405,41 @@ class UPNPService {
   }
 
   /**
+   * Attempt to add any port mapping to local IP.
+   * @param {String} remote - Remote IP.
+   * @param {Number} src - Remote port suggestion.
+   * @param {Number} dest - Local port.
+   * @param {String} description - Reservation description.
+   * @returns {Promise}
+   */
+
+  async addAnyPortMapping(remote, src, dest, description) {
+    const action = 'AddAnyPortMapping';
+    const local = IP.getPrivate();
+
+    if (local.length === 0)
+      throw new Error('Cannot determine local IP.');
+
+    const xml = await this.soapRequest(action, [
+      ['NewRemoteHost', remote],
+      ['NewExternalPort', src],
+      ['NewProtocol', 'TCP'],
+      ['NewInternalClient', local[0]],
+      ['NewInternalPort', dest],
+      ['NewEnabled', 'True'],
+      ['NewPortMappingDescription', description],
+      ['NewLeaseDuration', 0]
+    ]);
+
+    const child = xml.find('NewReservedPort');
+
+    if (!child)
+      throw new Error('Port mapping failed.');
+
+    return child.text;
+  }
+
+  /**
    * Attempt to add port mapping to local IP.
    * @param {String} remote - Remote IP.
    * @param {Number} src - Remote port.


### PR DESCRIPTION
When you have multiple clients talking to the same router the "AddAnyPortMapping" is nice because it deal with a collision with an existing reservation. I also added a description argument to the API. Making a PR in case this is something that might be useful to others.